### PR TITLE
keccak: add Modulo method

### DIFF
--- a/pkg/keccak/keccak.go
+++ b/pkg/keccak/keccak.go
@@ -82,3 +82,12 @@ func Pad(x, m int) ([]byte, error) {
 
 	return make([]byte, 0), nil
 }
+
+// Modulo returns a mod b
+func Modulo(a, b int) int {
+	tmp := a % b
+	if tmp < 0 {
+		return tmp + b
+	}
+	return tmp
+}


### PR DESCRIPTION
If we use % operator to calculate modulo of negative value (e.g. -1 %
        5), we can't get right result.
So we need custom modulo method to get right result.